### PR TITLE
Including 'sass.sync.js' in Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,8 @@
   "version": "0.8.2",
   "main": [
     "./dist/sass.js",
-    "./dist/sass.worker.js"
+    "./dist/sass.worker.js",
+    "./dist/sass.sync.js"
   ],
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Including the `dist/sass.sync.js` in the Bower registry. I realise it's not recommend for production, but in my case I want to provide basic inline SASS support for development &ndash; when working with my newly created [Maple framework](https://github.com/Wildhoney/Maple.js). Alternatively I could use the `WebWorker` but for development the configuration path required is an additional complication, and something I'd need to document. Using `dist/sass.sync.js` the developer merely needs to include it as a `script`, as opposed to configuring Maple :+1: 