### PR TITLE
Added missing second param to postMessage function call

### DIFF
--- a/src/sass.js
+++ b/src/sass.js
@@ -79,7 +79,7 @@ Sass.prototype = {
 
     options.id = 'cb' + Date.now() + Math.random();
     this._callbacks[options.id] = callback;
-    this._worker.postMessage(options);
+    this._worker.postMessage(options, '*');
   },
 
   _importerInit: function(args) {
@@ -89,7 +89,7 @@ Sass.prototype = {
       this._worker.postMessage({
         command: '_importerFinish',
         args: [result]
-      });
+      }, '*');
     }.bind(this);
 
     try {
@@ -111,7 +111,7 @@ Sass.prototype = {
     this._worker.postMessage({
       command: 'importer',
       args: [Boolean(importerCallback)]
-    });
+    }, '*');
 
     callback && callback();
   },

--- a/src/sass.worker.js
+++ b/src/sass.worker.js
@@ -8,7 +8,7 @@ var _importerInit = function(request, done) {
   postMessage({
     command: '_importerInit',
     args: [request]
-  });
+  }, '*');
 };
 
 var methods = {
@@ -34,7 +34,7 @@ onmessage = function (event) {
       postMessage({
         id: event.data.id,
         result: result
-      });
+      }, '*');
     } catch (e) {
       if (!result.error) {
         // unless we're dealing with a DataCloneError because of an Error instance,
@@ -53,7 +53,7 @@ onmessage = function (event) {
       postMessage({
         id: event.data.id,
         result: result
-      });
+      }, '*');
     }
   }
 


### PR DESCRIPTION
Added '*' as second parameter to function calls postMessage

This fixes the error

> Uncaught TypeError: Failed to execute 'postMessage' on 'Window': 2 arguments required, but only 1 present.