### PR TITLE
Add Sass instantiation to documentation for web worker

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,6 +17,7 @@ The regular way of running Sass.js in the browser is by using the Web Worker (se
 ```html
 <script src="dist/sass.js"></script>
 <script>
+  var sass = new Sass();
   var scss = '$someVar: 123px; .some-selector { width: $someVar; }';
   sass.compile(scss, function(result) {
     console.log(result);


### PR DESCRIPTION
The documentation is missing the instantiation of `Sass` in `getting-started.md`.