### PR TITLE
Use `var` instead of `const`

### DIFF
--- a/src/sass.configure.path.js
+++ b/src/sass.configure.path.js
@@ -10,7 +10,7 @@ var SASSJS_RELATIVE_PATH = (function() {
   'use strict';
 
   // in Node things are rather simple
-  const hasDir = typeof __dirname !== 'undefined';
+  var hasDir = typeof __dirname !== 'undefined';
   if (hasDir) {
     return __dirname;
   }


### PR DESCRIPTION
0.10.12 inadvertently requires ES6. This should bring the previous behavior back.

/CC @rodneyrehm 